### PR TITLE
Added compatibility with laravel's Mailer class.

### DIFF
--- a/src/Openbuildings/Postmark/Swift/Transport/PostmarkTransport.php
+++ b/src/Openbuildings/Postmark/Swift/Transport/PostmarkTransport.php
@@ -64,15 +64,13 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport {
 	 */
 	protected function getMIMEPart(\Swift_Mime_Message $message, $mime_type)
 	{
-		$part_content = NULL;
 		foreach ($message->getChildren() as $part)
 		{
 			if (strpos($part->getContentType(), $mime_type) === 0)
 			{
-				$part_content = $part;
+				return $part;
 			}
 		}
-		return $part_content;
 	}
 
 	/**
@@ -113,6 +111,7 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport {
 		switch ($message->getContentType())
 		{
 			case 'text/html':
+			case 'multipart/alternative':
 				$data['HtmlBody'] = $message->getBody();
 			break;
 			default:


### PR DESCRIPTION
All that is needed to do to use it with Laravel is:

``` php
\Mail::setSwiftMailer(Swift_PostmarkTransport::newInstance('API KEY HERE'));
```

A minor change was needed to make it work with Laravel.
When sending an HTML + plain-text email, Laravel uses `multipart/alternative` as the mimetype, which was throwing things off.

Also made the `getMIMEPart()` function a little better, by returning when it finds the part it's looking for rather than running through the entire loop.
