### PR TITLE
Make the send method return the Postmark API response array.

### DIFF
--- a/src/Openbuildings/Postmark/Swift/Transport/PostmarkTransport.php
+++ b/src/Openbuildings/Postmark/Swift/Transport/PostmarkTransport.php
@@ -141,7 +141,7 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport
             $data['Attachments'] = array();
 
             foreach ($message->getChildren() as $attachment) {
-                if (is_object($attachment) AND $attachment instanceof \Swift_Mime_Attachment) {
+                if (is_object($attachment) and $attachment instanceof \Swift_Mime_Attachment) {
                     $data['Attachments'][] = array(
                         'Name' => $attachment->getFilename(),
                         'Content' => base64_encode($attachment->getBody()),
@@ -158,7 +158,16 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport
             $this->_eventDispatcher->dispatchEvent($evt, 'sendPerformed');
         }
 
-        return $response;
+        if (isset($response['MessageID'])) {
+            $response_event = $this->_eventDispatcher->createResponseEvent(
+                $this,
+                $response['MessageID'],
+                true
+            );
+            $this->_eventDispatcher->dispatchEvent($response_event, 'responseReceived');
+        }
+
+        return 1;
     }
 
     /**

--- a/src/Openbuildings/Postmark/Swift/Transport/PostmarkTransport.php
+++ b/src/Openbuildings/Postmark/Swift/Transport/PostmarkTransport.php
@@ -151,14 +151,14 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport
             }
         }
 
-        $this->api()->send($data);
+        $response = $this->api()->send($data);
 
         if ($evt) {
             $evt->setResult(\Swift_Events_SendEvent::RESULT_SUCCESS);
             $this->_eventDispatcher->dispatchEvent($evt, 'sendPerformed');
         }
 
-        return 1;
+        return $response;
     }
 
     /**

--- a/tests/src/Swift/Transport/PostmarkTransportTest.php
+++ b/tests/src/Swift/Transport/PostmarkTransportTest.php
@@ -283,6 +283,47 @@ class Swift_Transport_PostmarkTransportTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Openbuildings\Postmark\Swift_Transport_PostmarkTransport::send
+     */
+    public function testResponseEventFires()
+    {
+        $event_dispatcher = $this->getMock('Swift_Events_SimpleEventDispatcher');
+        $transport = new Swift_Transport_PostmarkTransport($event_dispatcher);
+        $event = new Swift_Events_ResponseEvent($transport, 1234, true);
+        $api = $this->getMock('Openbuildings\Postmark\Api', array(), array('POSTMARK_API_TEST'));
+        $transport->api($api);
+
+        $api->expects($this->at(0))
+            ->method('send')
+            ->will($this->returnValue(array('MessageID' => 1234)));
+
+        $event_dispatcher->expects($this->once())
+            ->method('createResponseEvent')
+            ->with($this->equalTo($transport), $this->equalTo('1234'), $this->equalTo(true))
+            ->will($this->returnValue($event));
+
+        $event_dispatcher->expects($this->once())
+            ->method('dispatchEvent')
+            ->with($this->equalTo($event), $this->equalTo('responseReceived'));
+
+        $api->expects($this->at(1))
+            ->method('send')
+            ->will($this->returnValue(array()));
+
+        $message = Swift_Message::newInstance();
+        $message->setFrom('test12@example.com');
+        $message->setTo('test13@example.com');
+        $message->setSubject('Test Big');
+        $message->setBody('Text Body');
+
+        // Response Event should fire.
+        $transport->send($message);
+        
+        // Response Event should not fire.
+        $transport->send($message);
+    }
+
+    /**
      * @covers Openbuildings\Postmark\Swift_Transport_PostmarkTransport::__construct
      * @covers Openbuildings\Postmark\Swift_Transport_PostmarkTransport::registerPlugin
      */


### PR DESCRIPTION
This will make `$mailer->send($message);` return the parsed array response from the Postmark API.

Alternatively, I guess a `Swift_Events_ResponseEvent` could be fired to via "responseReceived" with a string representation of the response or just the message ID. Then an instance of `Swift_Events_ResponseListener` can be registered and get that response. Seems like over-engineering a simple problem, but it would avoid changing the `return 1` response from the `send()` method.

**Possible use case:** An email is sent and the message ID logged, then if Postmark reports a bounce, that log item can be retrieved and updated to reflect the bounced status.