### PR TITLE
Transport triggers `exceptionThrown` event when sending fails. Transport can have an event listener.

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -2,6 +2,9 @@
 
 namespace Openbuildings\Postmark;
 
+// Make it obvious when we're throwing a custom exception
+use Openbuildings\Postmark\Exception as PostmarkException;
+
 /**
  * Class for manupulating a server
  *
@@ -58,9 +61,8 @@ class Api
 
     /**
      * Get the headers needed to be sent to the Postmark API.
-     *
      * @return array of header strings
-     * @throws Exception If the Postmark API token is not yet set.
+     * @throws \Exception
      */
     public function getHeaders()
     {
@@ -81,8 +83,8 @@ class Api
      *
      * @param array $data
      * @return array Postmark API response.
-     * @throws Exception If API request failed or JSON returned was invalid.
-     * @throws Openbuildings\Postmark\Exception If Postmark API returned an error.
+     * @throws \Exception If API request failed or JSON returned was invalid.
+     * @throws PostmarkException If Postmark API returned an error.
      * @uses Openbuildings\Postmark\Api::getSendUri to determine the request URI
      * @uses Openbuildings\Postmark\Api::getHeaders for the request headers
      */
@@ -120,7 +122,7 @@ class Api
         $responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
         if ($responseCode != 200) {
-            throw new Exception(
+            throw new PostmarkException(
                 sprintf('Postmark delivery failed: %s', $response['Message']),
                 (int) $response['ErrorCode']
             );

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -52,6 +52,8 @@ class Exception extends Swift_TransportException
      * Create a new Exception with $message and $code
      *
      * @param string $message
+     * @param int $code
+     * @param \Exception $previous
      */
     public function __construct($message = '', $code = 0, \Exception $previous = null)
     {

--- a/src/Swift_PostmarkTransport.php
+++ b/src/Swift_PostmarkTransport.php
@@ -18,8 +18,9 @@ class Swift_PostmarkTransport extends Swift_Transport_PostmarkTransport
      * Create a new PostmarkTransport.
      *
      * @param null|string $token
+     * @param \Swift_Events_EventListener $listener
      */
-    public function __construct($token = null)
+    public function __construct($token = null, \Swift_Events_EventListener $listener = null)
     {
         Swift_DependencyContainer::getInstance()
             ->register('transport.postmark')
@@ -34,6 +35,10 @@ class Swift_PostmarkTransport extends Swift_Transport_PostmarkTransport
 
         if ($token) {
             $this->setApi(new Api($token));
+        }
+
+        if ($listener) {
+            $this->registerPlugin($listener);
         }
     }
 


### PR DESCRIPTION
Thanks for your work on this. Actually using the postmark API makes error handling much easier!

I've added some code to have the `exceptionThrown` Swift event triggered when an error occurs with the API call.

In order to catch Swift events, I've also added an option to connect an event listener to the Transport.

In the case of `exceptionThrown` events, the message is added to the Transport so it can be accessed from the event listener.

Here's the event listener I use:

```php
use Openbuildings\Postmark\Swift_Transport_PostmarkTransport;

class SwiftmailerListener implements \Swift_Events_TransportExceptionListener
{
    /**
     * Invoked as a TransportException is thrown in the Transport system.
     *
     * @param \Swift_Events_TransportExceptionEvent $evt
     */
    public function exceptionThrown(\Swift_Events_TransportExceptionEvent $evt)
    {
        $source = $evt->getSource();
        if (!($source instanceof Swift_Transport_PostmarkTransport)) {
            //Not a great deal we can do because we don't have access to the message
            return;
        }

        $message = $source->getMessage();

        //Log the error and maybe inform the sender?
    }
}
```

Finally, in looking through the code and making my changes, I added leading slashes to some of the namespacing to quiet phpStorm.

Let me know if there's anything you'd like me to change or clarify.