### PR TITLE
Adding support for Postmark Tags

### DIFF
--- a/src/Swift_Transport_PostmarkTransport.php
+++ b/src/Swift_Transport_PostmarkTransport.php
@@ -158,6 +158,11 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport
             $data['HtmlBody'] = $html->getBody();
         }
 
+        $tag = $message->getId();
+        if (strlen($tag)) {
+            $data['Tag'] = $tag;
+        }
+
         if ($message->getChildren()) {
             $data['Attachments'] = array();
 


### PR DESCRIPTION
Postmark has support for tagging emails to aid with statistics. I think we can use the Swift ID property to do the same thing.

Swift automatically generates a 'unique' ID like `[hash]@[domain]` but you can set your own with `$message->setId('blah');` and this bit of code will tag the Postmark message with that ID.

I think this would technically be a BC break because it changes the default behaviour - Emails used to be sent with no tag, but they'll now default to sending with Swift's auto-generated tag.