### PR TITLE
Adding multipart/mixed as an html content type.

### DIFF
--- a/src/Swift_Transport_PostmarkTransport.php
+++ b/src/Swift_Transport_PostmarkTransport.php
@@ -143,6 +143,7 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport
         switch ($message->getContentType()) {
             case 'text/html':
             case 'multipart/alternative':
+            case 'multipart/mixed':
                 $data['HtmlBody'] = $message->getBody();
                 break;
             default:


### PR DESCRIPTION
In some cases the Swift content type changes to `multipart/mixed`. I believe the message should be treated as `html` rather than `text`.

Unfortunately I can't find any clear documentation on exactly when the content type changes. In my case I noticed it when creating an html email which includes inline images and/or document attachments.