### PR TITLE
Set Content-ID only for inline attachements

### DIFF
--- a/src/Swift_Transport_PostmarkTransport.php
+++ b/src/Swift_Transport_PostmarkTransport.php
@@ -163,12 +163,17 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport
 
             foreach ($message->getChildren() as $attachment) {
                 if (is_object($attachment) and $attachment instanceof \Swift_Mime_Attachment) {
-                    $data['Attachments'][] = array(
+                    $attachmentData = array(
                         'Name' => $attachment->getFilename(),
                         'Content' => base64_encode($attachment->getBody()),
                         'ContentType' => $attachment->getContentType(),
-                        'ContentID' => sprintf('cid:%s', $attachment->getId())
                     );
+
+                    if ($attachment->getDisposition() != 'attachment' && $attachment->getId() != null) {
+                        $attachmentData['ContentID'] = 'cid:'.$attachment->getId();
+                    }
+
+                    $data['Attachments'][] = $attachmentData;
                 }
             }
         }

--- a/tests/src/Swift_Transport_PostmarkTransportTest.php
+++ b/tests/src/Swift_Transport_PostmarkTransportTest.php
@@ -181,6 +181,8 @@ class Swift_Transport_PostmarkTransportTest extends PHPUnit_Framework_TestCase
             );
 
         $attachment1 = Swift_Attachment::fromPath(__DIR__ . '/../test_data/logo_black.png');
+        $attachment1->setDisposition('inline');
+        $attachment1->setId('test@example.com');
 
         $api->expects($this->at(2))
             ->method('send')
@@ -208,6 +210,7 @@ class Swift_Transport_PostmarkTransportTest extends PHPUnit_Framework_TestCase
             );
 
         $attachment2 = Swift_Attachment::fromPath(__DIR__ . '/../test_data/logo_black.png');
+        $attachment2->setDisposition('attachment');
 
         $api->expects($this->at(3))
             ->method('send')
@@ -223,7 +226,6 @@ class Swift_Transport_PostmarkTransportTest extends PHPUnit_Framework_TestCase
                                 'Name' => 'logo_black.png',
                                 'Content' => 'iVBORw0KGgoAAAANSUhEUgAAAHsAAAASCAYAAAB7PKHtAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAABR0RVh0Q3JlYXRpb24gVGltZQAyLzcvMTOGU1gaAAAAHHRFWHRTb2Z0d2FyZQBBZG9iZSBGaXJld29ya3MgQ1M26LyyjAAAA+ZJREFUaIHtmeF12zYQx3/W83drA6kTRJkg7ATWBqUniDJB6AmiTlB6gsoThNmA2YDeQJmg/XDAI3S8A0G7TZ22//fwLIL3B+6Aw90RvsJGDeyBHbAJfV+BATgBrZLfAcfkuTVkLOR4dWgeBqAP+gzq3TGM7aFPuOcZblWgq4VOzXdw5LaInVWY4yb0f0HsatVYFv8Q+G8Ut8vpuAtCf8y0AXGGiEq9bzLKpcjxmgI9vPm6Qt5Z2WFxPV3P5B0qle0cmVIbe2euuoA7GDYWEXWrArdS/Y23Ago5XrNQl/TUdQu5+wzX0zUu5NqxbW6zl+rYK76lT27D19eBqEMUwFPoi5PsEYeIYebBMeLvwgOX4XrPGLYA3iP6pjIR98nvdeBukr4jEtKXYoOEycnJmUELvFN9D4xpJer4S3j3xHiwInRaeGAM2XsubaxJ0lXHpSe02B67xs4hleI3BtdCjteod5XBPzj8TvVbODnje1yta9qsfOydbD3O2bENJB932CH87Iyf4oA6xDs1+YAfmiL0+wp70eeQ4zXYm6H1sBa1w96wFHtnbo+rddVNb4i32drJvMJtDkv3jBXTENQwrVA15t5/L7xEj5fa8KSeTxQsOHCrxtDpsxRfkt8bZMOP+FGCFVOPfE7u+qdQq+fuO3FB0tlj8hzzdw4la30MulhNf/qluEHqls/IaT+hbLxm6o2v5dRq6IWqmIZAz1Er9VwzFj8A33hesVkHXiwUb5HI2DjyJWu9Y1q8WWiD7Hvn/W1oh6Bnf+0IvkZ8mnn/yPTzJOLzDLdZrI3gzLjh8SvlI+WOUxL2c4gFWIOk4xtD5k3QZ7syFFv6GfEa8Ej+ti2He56fN8G+HfMiTKeeK0OmDTrFNocBsX0NvAU+ILedKW6CzKQq1QqVoMKubF/Ca8hXvwOyMJUxbjfD7ZEN3hZwS3Ql6OLN1yVyvXpn6Z/iuXtTa+4K8cK0snxH/nOgDgq/NAQtxc/AVdK2jCF0Dleq7RAbh79QvwPTE2VBR5EW2+nmsEZs9yJxqztW4a/e3E+IE6RF0T70/caYBzxsEY/1Wu5O+UdFzN/fZuRaLp1igxyehnHT4w1alxnnhBzM34NcrfjaqS7GasmHPqtVgVst5HUOr0n0aZy5StAp7hJ43JyuKWp8eyN2XN6AlbZYC+ibw5K2jSc7KllSEIB4751hxP+QQ/PrjEyPOE9J2AdZ73vGkH1ECrG5KBJxBwwr1dkAPyGX6tZAT4ghO8r+X/1fRUn+jv+2vMvIfkU2dcs0ksQC06q+Ix6RCr0FKVZy2DLmgZ7Xe+Hyb0EV/p7x7wxy2CH52uT/Cao6KpIl3Ep0AAAAAElFTkSuQmCC',
                                 'ContentType' => 'image/png',
-                                'ContentID' => 'cid:' . $attachment2->getId()
                             ),
                         )
                     )


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/OpenBuildings/postmark/pull/24

When a Content-ID header is set for an attachement with `Content-Disposition: attachement`
the attachement is converted to inline via Postmark and the Mac OS Mail.app does not show
the attachement properly.