### PR TITLE
Allow for case 'multipart/related'

### DIFF
--- a/src/Swift_Transport_PostmarkTransport.php
+++ b/src/Swift_Transport_PostmarkTransport.php
@@ -142,6 +142,7 @@ class Swift_Transport_PostmarkTransport implements \Swift_Transport
 
         switch ($message->getContentType()) {
             case 'text/html':
+            case 'multipart/related':
             case 'multipart/alternative':
                 $data['HtmlBody'] = $message->getBody();
                 break;


### PR DESCRIPTION
issue #42  messages with embedded images should be of the type 'multipart/related'. Swiftmailer sets this automatically, but the HTML was put into the plain text body because this MIME type was not considered.